### PR TITLE
Update panzoom version to 9.2.1

### DIFF
--- a/dist/vue-panzoom.esm.js
+++ b/dist/vue-panzoom.esm.js
@@ -80,6 +80,15 @@ var PanZoomComponent = {
             this.$panZoomInstance.on('transform', function (e) {
                 this$1.$emit('transform', e);
             });
+        },
+        isPaused: function isPaused() {
+            this.$panZoomInstance.isPaused();
+        },
+        pause: function pause() {
+            this.$panZoomInstance.pause();
+        },
+        resume: function resume() {
+            this.$panZoomInstance.resume();
         }
     }
 };

--- a/dist/vue-panzoom.min.js
+++ b/dist/vue-panzoom.min.js
@@ -83,6 +83,15 @@ var VuePanZoom = (function (panZoom) {
                 this.$panZoomInstance.on('transform', function (e) {
                     this$1.$emit('transform', e);
                 });
+            },
+            isPaused: function isPaused() {
+                this.$panZoomInstance.isPaused();
+            },
+            pause: function pause() {
+                this.$panZoomInstance.pause();
+            },
+            resume: function resume() {
+                this.$panZoomInstance.resume();
             }
         }
     };

--- a/dist/vue-panzoom.umd.js
+++ b/dist/vue-panzoom.umd.js
@@ -86,6 +86,15 @@
                 this.$panZoomInstance.on('transform', function (e) {
                     this$1.$emit('transform', e);
                 });
+            },
+            isPaused: function isPaused() {
+                this.$panZoomInstance.isPaused();
+            },
+            pause: function pause() {
+                this.$panZoomInstance.pause();
+            },
+            resume: function resume() {
+                this.$panZoomInstance.resume();
             }
         }
     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -4958,7 +4958,6 @@
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5154,8 +5153,7 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5245,8 +5243,7 @@
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -5482,13 +5479,13 @@
       }
     },
     "globule": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
-      "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.1.tgz",
+      "integrity": "sha512-OVyWOHgw29yosRHCHo7NncwR1hW5ew0W/UrvtwvjefVJeQ26q4/8r8FmPsSF1hJ93IgWkyv16pCTz6WblMzm/g==",
       "dev": true,
       "requires": {
         "glob": "~7.1.1",
-        "lodash": "~4.17.10",
+        "lodash": "~4.17.12",
         "minimatch": "~3.0.2"
       }
     },
@@ -5995,9 +5992,9 @@
       "dev": true
     },
     "in-publish": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
-      "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.1.tgz",
+      "integrity": "sha512-oDM0kUSNFC31ShNxHKUyfZKy8ZeXZBWMjMdZHKLOk13uvT27VTL/QzRGfRUcevJhpkZAvlhPYuXkF7eNWrtyxQ==",
       "dev": true
     },
     "indent-string": {
@@ -6249,13 +6246,10 @@
       "dev": true
     },
     "is-finite": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "^1.0.0"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -6761,18 +6755,6 @@
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
-    "lodash.assign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
-      "dev": true
-    },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-      "dev": true
-    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -6801,12 +6783,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
-      "dev": true
-    },
-    "lodash.mergewith": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
-      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
       "dev": true
     },
     "lodash.tail": {
@@ -7305,7 +7281,8 @@
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
       "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -7339,9 +7316,9 @@
       "dev": true
     },
     "ngraph.events": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/ngraph.events/-/ngraph.events-0.0.4.tgz",
-      "integrity": "sha1-css2RIjdD9fwV0WESfajsXpyLZo="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ngraph.events/-/ngraph.events-1.2.1.tgz",
+      "integrity": "sha512-D4C+nXH/RFxioGXQdHu8ELDtC6EaCiNsZtih0IvyGN81OZSUby4jXoJ5+RNWasfsd0FnKxxpAROyUMzw64QNsw=="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -7399,20 +7376,6 @@
             "block-stream": "*",
             "fstream": "^1.0.12",
             "inherits": "2"
-          },
-          "dependencies": {
-            "fstream": {
-              "version": "1.0.12",
-              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-              "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-              "dev": true,
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "inherits": "~2.0.0",
-                "mkdirp": ">=0.5 0",
-                "rimraf": "2"
-              }
-            }
           }
         }
       }
@@ -7477,9 +7440,9 @@
       }
     },
     "node-sass": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.11.0.tgz",
-      "integrity": "sha512-bHUdHTphgQJZaF1LASx0kAviPH7sGlcyNhWade4eVIpFp6tsn7SV8xNMTbsQFpEV9VXpnwTTnNYlfsZXgGgmkA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.1.tgz",
+      "integrity": "sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==",
       "dev": true,
       "requires": {
         "async-foreach": "^0.1.3",
@@ -7489,12 +7452,10 @@
         "get-stdin": "^4.0.1",
         "glob": "^7.0.3",
         "in-publish": "^2.0.0",
-        "lodash.assign": "^4.2.0",
-        "lodash.clonedeep": "^4.3.2",
-        "lodash.mergewith": "^4.6.0",
+        "lodash": "^4.17.15",
         "meow": "^3.7.0",
         "mkdirp": "^0.5.1",
-        "nan": "^2.10.0",
+        "nan": "^2.13.2",
         "node-gyp": "^3.8.0",
         "npmlog": "^4.0.0",
         "request": "^2.88.0",
@@ -7547,6 +7508,12 @@
             "pseudomap": "^1.0.2",
             "yallist": "^2.1.2"
           }
+        },
+        "nan": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+          "dev": true
         },
         "strip-ansi": {
           "version": "3.0.1",
@@ -7927,13 +7894,13 @@
       "dev": true
     },
     "panzoom": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/panzoom/-/panzoom-7.1.2.tgz",
-      "integrity": "sha512-KJKJe8OimKPpJv2SxwEpJXitxMAaBM938Ek9JwXgBH20fFr/PworjeiVY3VfabYV3YtWVw8rqMOj8mON6eYPVA==",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/panzoom/-/panzoom-9.2.1.tgz",
+      "integrity": "sha512-jFEpjlttb++pJfpODp76VAPh5RpQynRqrtlgVvvCHFQEmH0y+lQ17fzL/vnnAeNWZgc2b7eI1fNgug7M1TvT2w==",
       "requires": {
         "amator": "^1.1.0",
-        "ngraph.events": "0.0.4",
-        "wheel": "0.0.5"
+        "ngraph.events": "^1.0.0",
+        "wheel": "^1.0.0"
       }
     },
     "parallel-transform": {
@@ -11836,9 +11803,9 @@
       "dev": true
     },
     "wheel": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/wheel/-/wheel-0.0.5.tgz",
-      "integrity": "sha1-i00JMOcsm437uQeDPuMz3pewFPo="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wheel/-/wheel-1.0.0.tgz",
+      "integrity": "sha512-XiCMHibOiqalCQ+BaNSwRoZ9FDTAvOsXxGHXChBugewDj7HC8VBIER71dEOiRH1fSdLbRCQzngKTSiZ06ZQzeA=="
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -11,13 +11,13 @@
     "build:all": "npm run build:umd && npm run build:es && npm run build:unpkg"
   },
   "dependencies": {
-    "panzoom": "^8.6.2",
+    "panzoom": "^9.2.1",
     "vue": "^2.5.21"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^3.3.0",
     "@vue/cli-service": "^3.3.0",
-    "node-sass": "^4.9.0",
+    "node-sass": "^4.13.1",
     "rollup": "^1.22.0",
     "rollup-plugin-buble": "^0.19.8",
     "rollup-plugin-commonjs": "^10.1.0",


### PR DESCRIPTION
Hi,
thanks for your library! Works like a charm. I need the latest panzoom version, though, so it would be great if you could merge this and then release a new version of vue-panzoom.

Here's what I did
- updated panzoom version to 9.2.1
- updated node-sass to fix failing `npm install`
- rebuilt the dist files