### PR TITLE
Deal with `#text` nodes from whitespaces

### DIFF
--- a/src/components/pan-zoom/script.js
+++ b/src/components/pan-zoom/script.js
@@ -39,7 +39,10 @@ const PanZoomComponent = {
             else {
                 el = _wrapper.querySelector('svg, object, embed');
                 if (!el) {
-                    el = _wrapper.firstChild;
+                  for(let i = 0; i < _wrapper.childNodes.length; i++){
+                    if(_wrapper.childNodes[i].nodeName !== '#text')
+                      el = _wrapper.childNodes[i]
+                  }
                 }
             }
             return el;


### PR DESCRIPTION
Depending on the build setup whitespaces will potentially be turned into `#text` nodes, so when querying for the **first child node** as the current code does it breaks the plugin. Instead, it should ignore `#text` nodes and pick the node that the user actually intended to be used.

This change should not break setups where whitespaces are not kept and therefore turned into `#text` nodes as if there's a single node, then the system will take that instance anyway (same as it used to do with `firstChild`.

See [mdn reference](https://developer.mozilla.org/en-US/docs/Web/API/Node/firstChild#example).